### PR TITLE
feat: only add autoload on install (#16)

### DIFF
--- a/src/Composer/ComposerPlugin.php
+++ b/src/Composer/ComposerPlugin.php
@@ -46,10 +46,10 @@ class ComposerPlugin implements PluginInterface, EventSubscriberInterface
             return [];
         }
 
-        $method = 'updateRuntime';
         $priority = 1;
         return [
-            ScriptEvents::PRE_AUTOLOAD_DUMP => [$method, $priority],
+            ScriptEvents::POST_INSTALL_CMD => ['generateRuntime', $priority],
+            ScriptEvents::PRE_AUTOLOAD_DUMP => ['updateRuntime', $priority],
         ];
     }
 
@@ -68,13 +68,22 @@ class ComposerPlugin implements PluginInterface, EventSubscriberInterface
     }
 
     /**
-     * @throws JsonException
      * @throws InvalidArgumentException
      *  if the configured template file does not exist
      */
     public function updateRuntime(): void
     {
         $this->runtimeFile->updateRuntimeFile($this->io);
+    }
+
+    /**
+     * @throws JsonException
+     * @throws InvalidArgumentException
+     *  if the configured template file does not exist
+     */
+    public function generateRuntime(): void
+    {
+        $this->updateRuntime();
         $this->composerJson->addAutoloadFile(
             $this->runtimeFile->getRuntimeFilePath(),
         );

--- a/test/Composer/ComposerPluginTest.php
+++ b/test/Composer/ComposerPluginTest.php
@@ -41,10 +41,10 @@ class ComposerPluginTest extends TestCase
         $plugin = new ComposerPlugin();
         $plugin->activate($composer, $io);
 
-        $method = 'updateRuntime';
         $priority = 1;
         $exprected = [
-            ScriptEvents::PRE_AUTOLOAD_DUMP => [$method, $priority],
+            ScriptEvents::POST_INSTALL_CMD => ['generateRuntime', $priority],
+            ScriptEvents::PRE_AUTOLOAD_DUMP => ['updateRuntime', $priority],
         ];
 
         $this->assertEquals(
@@ -54,7 +54,7 @@ class ComposerPluginTest extends TestCase
         );
     }
 
-    public function testUpdateRuntime(): void
+    public function testGenerateRuntime(): void
     {
 
         $composer = $this->createStub(Composer::class);
@@ -78,7 +78,7 @@ class ComposerPluginTest extends TestCase
             ->willReturn($composerJson);
 
         $plugin->activate($composer, $io);
-        $plugin->updateRuntime();
+        $plugin->generateRuntime();
     }
 
     public function testUninstall(): void


### PR DESCRIPTION
The first status was reverted. Therefore, a new merge request showing the existing problem that still needs to be corrected.

The problem is that in a new project, `atoolo_runtime.php` is no longer entered in `vendor/composer/autoload_static.php` and `vendor/composer/autoload_files.php`.

Reproduce as follows

```sh
symfony new test --version="^7.3"
cd test
composer config platform-check true
composer config --no-plugins allow-plugins.atoolo/runtime true

composer require --no-interaction atoolo/runtime:dev-feature/only_add_autoload_on_install
```

To be checked with

```
grep atoolo_runtime.php vendor/composer/autoload_static.php
```

Cross-check with

```
composer require --no-interaction atoolo/runtime
grep atoolo_runtime.php vendor/composer/autoload_static.php
```

Returns
```
        '44241b3ce1f89a49599a2ed4bb359480' => __DIR__ . '/..' . '/atoolo_runtime.php',
```
